### PR TITLE
feat: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.19-alpine
+
+WORKDIR /app
+COPY . /app
+
+RUN go mod download
+RUN go build -o bin/cloudflare-dynamic-dns main.go
+
+ENTRYPOINT ["bin/cloudflare-dynamic-dns"]


### PR DESCRIPTION
Will only work on linux and require `--net=host` (https://docs.docker.com/network/drivers/host/).

Fix #59 