### PR TITLE
feat: support for ipv4 stack

### DIFF
--- a/cmd/cloudflare.go
+++ b/cmd/cloudflare.go
@@ -11,15 +11,7 @@ import (
 
 func processDomain(api *cloudflare.API, domain string, addr string, cfg runConfig) {
 	ctx := context.Background()
-
-	recordType := ""
-	if cfg.stack == ipv4 {
-		recordType = "A"
-	} else if cfg.stack == ipv6 {
-		recordType = "AAAA"
-	} else {
-		log.WithField("stack", cfg.stack).Fatal("Invalid IP mode")
-	}
+	recordType := getRecordType(cfg.stack)
 
 	zoneID, err := api.ZoneIDByName(getZoneFromDomain(domain))
 	if err != nil {
@@ -112,6 +104,17 @@ func processDomain(api *cloudflare.API, domain string, addr string, cfg runConfi
 	if !updated {
 		createNewDNSRecord(api, zoneID, desiredDNSRecord)
 	}
+}
+
+func getRecordType(stack stack) string {
+	if stack == ipv4 {
+		return "A"
+	}
+	if stack == ipv6 {
+		return "AAAA"
+	}
+	log.WithField("stack", stack).Fatal("Invalid IP mode")
+	return ""
 }
 
 func createNewDNSRecord(api *cloudflare.API, zoneID string, desiredDNSRecord cloudflare.DNSRecord) {

--- a/cmd/cloudflare.go
+++ b/cmd/cloudflare.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	log "github.com/sirupsen/logrus"
+)
+
+func processDomain(api *cloudflare.API, domain string, addr string, cfg runConfig) {
+	ctx := context.Background()
+
+	recordType := ""
+	if cfg.stack == ipv4 {
+		recordType = "A"
+	} else if cfg.stack == ipv6 {
+		recordType = "AAAA"
+	} else {
+		log.WithField("stack", cfg.stack).Fatal("Invalid IP mode")
+	}
+
+	zoneID, err := api.ZoneIDByName(getZoneFromDomain(domain))
+	if err != nil {
+		log.WithError(err).Fatal("Couldn't get ZoneID")
+	}
+
+	desiredDNSRecord := cloudflare.DNSRecord{Type: recordType, Name: domain, Content: addr, TTL: cfg.ttl}
+	if cfg.multihost {
+		desiredDNSRecord.Comment = cfg.hostId
+	}
+
+	if cfg.proxy != "auto" {
+		desiredDNSRecord.Proxied = Ptr(cfg.proxy == "enabled")
+	}
+
+	dnsRecordFilter := cloudflare.ListDNSRecordsParams{Type: recordType, Name: domain}
+	existingDNSRecords, _, err := api.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(zoneID), dnsRecordFilter)
+	if err != nil {
+		log.WithError(err).WithField("filter", dnsRecordFilter).Fatal("Couldn't get DNS records")
+	}
+
+	// If there are no existing records, create a new one and exit.
+	if len(existingDNSRecords) == 0 {
+		createNewDNSRecord(api, zoneID, desiredDNSRecord)
+		return
+	}
+
+	// If there is already a record with the same address, we want to process it
+	// first. Cloudflare API doesn't allow creating multiple records with the
+	// same address, which may happen in the multihost mode.
+	sort.Slice(existingDNSRecords, func(i, j int) bool {
+		return existingDNSRecords[i].Content == addr
+	})
+	for _, record := range existingDNSRecords {
+		log.WithFields(log.Fields{
+			"comment": record.Comment,
+			"content": record.Content,
+			"domain":  record.Name,
+			"proxied": *record.Proxied,
+			"ttl":     record.TTL,
+			"type":    record.Type,
+		}).Debug("Found DNS record")
+	}
+
+	sameHostFn := func(record cloudflare.DNSRecord, cfg runConfig) bool {
+		recHost := strings.Split(record.Comment, " ")[0]
+		cfgHost := strings.Split(cfg.hostId, " ")[0]
+		return recHost == cfgHost
+	}
+
+	// Update the current record if it is either:
+	//   1. has the same address as the desired record (proxied, ttl, or comment may have changed),
+	//   2. has the same comment as the desired record and multihost is enabled (address and possibly proxied or ttl have changed),
+	//   3. has empty comment and multihost is disabled (address and possibly proxied or ttl have changed).
+	// NOTE: despite API returning empty Comment as `null`, cloudflare-go represents it as an empty string.
+	//       This can break in the future.
+	shouldUpdateFn := func(record cloudflare.DNSRecord, cfg runConfig) bool {
+		return record.Content == addr ||
+			cfg.multihost && sameHostFn(record, cfg) ||
+			!cfg.multihost && record.Comment == ""
+	}
+
+	// Look through all existing records.
+	// Update the matching record if found, delete the rest.
+	// If no matching record is found, create a new one.
+	updated := false
+	for _, record := range existingDNSRecords {
+		if !updated && shouldUpdateFn(record, cfg) {
+			updateDNSRecord(api, zoneID, record, desiredDNSRecord)
+			updated = true
+			continue
+		}
+
+		// In multihost mode, delete all records with the same host-id as the
+		// current host. This should not happen during normal operation.
+		if updated && record.Comment == cfg.hostId && cfg.multihost {
+			log.WithField("record", record).
+				Warn("Found another record with the same host-id as the current host, deleting it")
+			deleteDNSRecord(api, zoneID, record)
+			continue
+		}
+
+		// In single host mode, delete all other records.
+		if updated && !cfg.multihost {
+			deleteDNSRecord(api, zoneID, record)
+			continue
+		}
+	}
+
+	if !updated {
+		createNewDNSRecord(api, zoneID, desiredDNSRecord)
+	}
+}
+
+func createNewDNSRecord(api *cloudflare.API, zoneID string, desiredDNSRecord cloudflare.DNSRecord) {
+	ctx := context.Background()
+	log.WithField("record", desiredDNSRecord).Info("Create new DNS record")
+	_, err := api.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.CreateDNSRecordParams{
+		Comment: desiredDNSRecord.Comment,
+		Content: desiredDNSRecord.Content,
+		Name:    desiredDNSRecord.Name,
+		Proxied: desiredDNSRecord.Proxied,
+		TTL:     desiredDNSRecord.TTL,
+		Type:    desiredDNSRecord.Type,
+	})
+	if err != nil {
+		log.WithError(err).Fatal("Couldn't create DNS record")
+	}
+}
+
+func updateDNSRecord(api *cloudflare.API, zoneID string, oldRecord cloudflare.DNSRecord, newRecord cloudflare.DNSRecord) {
+	ctx := context.Background()
+	proxiedMatches := newRecord.Proxied == nil ||
+		(oldRecord.Proxied != nil && *oldRecord.Proxied == *newRecord.Proxied)
+	if oldRecord.Content == newRecord.Content &&
+		proxiedMatches &&
+		oldRecord.TTL == newRecord.TTL &&
+		oldRecord.Comment == newRecord.Comment {
+		log.WithField("record", oldRecord).Info("DNS record is up to date")
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"new": newRecord,
+		"old": oldRecord,
+	}).Info("Updating existing DNS record")
+	_, err := api.UpdateDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.UpdateDNSRecordParams{
+		Comment: &newRecord.Comment,
+		Content: newRecord.Content,
+		ID:      oldRecord.ID,
+		Name:    newRecord.Name,
+		Proxied: newRecord.Proxied,
+		TTL:     newRecord.TTL,
+		Type:    newRecord.Type,
+	})
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"new": newRecord,
+			"old": oldRecord,
+		}).Fatal("Couldn't update DNS record")
+	}
+}
+
+func deleteDNSRecord(api *cloudflare.API, zoneID string, record cloudflare.DNSRecord) {
+	ctx := context.Background()
+	log.WithField("record", record).Info("Deleting DNS record")
+	err := api.DeleteDNSRecord(ctx, cloudflare.ZoneIdentifier(zoneID), record.ID)
+	if err != nil {
+		log.WithError(err).WithField("record", record).Fatal("Couldn't delete DNS record")
+	}
+}
+
+func getZoneFromDomain(domain string) string {
+	parts := strings.Split(domain, ".")
+	return strings.Join(parts[len(parts)-2:], ".")
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -379,10 +379,10 @@ func logConfig(cfg runConfig) {
 }
 
 func run(cfg runConfig) {
-	bs := baseIpStack{cfg}
-	ip := bs.getIP()
+	ipMgr := newIpManager(cfg)
+	ip := ipMgr.getIP()
 
-	if cfg.stateFilepath != "" && ip == bs.getOldIp() {
+	if cfg.stateFilepath != "" && ip == ipMgr.getOldIp() {
 		log.Info("The address hasn't changed, nothing to do")
 		log.Info("To bypass this check run without the --state-file flag or remove the state file: ", cfg.stateFilepath)
 		return
@@ -399,7 +399,7 @@ func run(cfg runConfig) {
 	}
 
 	if cfg.stateFilepath != "" {
-		bs.setOldIp(ip)
+		ipMgr.setOldIp(ip)
 	}
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -379,7 +379,7 @@ func logConfig(cfg runConfig) {
 }
 
 func run(cfg runConfig) {
-	bs := baseIpStack{cfg}
+	bs := newStack(cfg)
 	ip := bs.getIP()
 
 	if cfg.stateFilepath != "" && ip == bs.getOldIp() {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"crypto/md5"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -311,7 +311,9 @@ func collectConfiguration() runConfig {
 	}
 
 	if stateFileEnabled && stateFilepath == "" {
-		stateFilepath = fmt.Sprintf("%s_%s_%x", iface, stack, md5.Sum([]byte(strings.Join(domains, "_"))))
+		h := fnv.New64a()
+		domainHash := h.Sum([]byte(strings.Join(domains, " ")))
+		stateFilepath = fmt.Sprintf("%s_%s_%x", iface, stack, domainHash)
 		// If STATE_DIRECTORY is set, use it as the state file directory,
 		// otherwise use the current directory.
 		if stateDir := os.Getenv("STATE_DIRECTORY"); stateDir != "" {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -379,7 +379,7 @@ func logConfig(cfg runConfig) {
 }
 
 func run(cfg runConfig) {
-	bs := newStack(cfg)
+	bs := baseIpStack{cfg}
 	ip := bs.getIP()
 
 	if cfg.stateFilepath != "" && ip == bs.getOldIp() {

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -8,10 +8,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type ipStack interface {
-	getIP() string
-}
-
 type ipStackUtil interface {
 	filterIPs([]net.IP) []net.IP
 	sortIPs([]net.IP) []net.IP
@@ -28,10 +24,6 @@ type ipv4Stack struct {
 
 type ipv6Stack struct {
 	baseIpStack
-}
-
-func newStack(cfg runConfig) ipStack {
-	return baseIpStack{cfg}
 }
 
 func (bs baseIpStack) newStack() ipStackUtil {

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"net"
+	"os"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ipStack interface {
+	getIP() string
+}
+
+type ipStackUtil interface {
+	filterIPs([]net.IP) []net.IP
+	sortIPs([]net.IP) []net.IP
+	logIP(net.IP)
+}
+
+type baseIpStack struct {
+	cfg runConfig
+}
+
+type ipv4Stack struct {
+	baseIpStack
+}
+
+type ipv6Stack struct {
+	baseIpStack
+}
+
+func newStack(cfg runConfig) ipStack {
+	return baseIpStack{cfg}
+}
+
+func (bs baseIpStack) newStack() ipStackUtil {
+	switch bs.cfg.stack {
+	case ipv4:
+		return ipv4Stack{bs}
+	case ipv6:
+		return ipv6Stack{bs}
+	default:
+		log.WithField("stack", bs.cfg.stack).Fatal("Unknown stack")
+		return nil
+	}
+}
+
+func (bs baseIpStack) getIP() string {
+	s := bs.newStack()
+	ips := bs.getAllIPs()
+	ips = s.filterIPs(ips)
+	if len(ips) == 0 {
+		log.Fatal("No suitable addresses found")
+	}
+	ips = s.sortIPs(ips)
+	ip := bs.pickIP(ips)
+	log.WithField("addresses", ips).Infof("Found %d public IPv6 addresses, selected %s", len(ips), ip)
+	s.logIP(ip)
+	return ip.String()
+}
+
+func (s baseIpStack) getAllIPs() []net.IP {
+	iface := s.cfg.iface
+	netIface, err := net.InterfaceByName(iface)
+	if err != nil {
+		log.WithError(err).WithField("iface", iface).Fatal("Can't get the interface")
+	}
+	log.WithField("interface", netIface).Debug("Found the interface")
+
+	addrs, err := netIface.Addrs()
+	if err != nil {
+		log.WithError(err).Fatal("Couldn't get interface addresses")
+	}
+
+	ips := []net.IP{}
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			log.WithError(err).WithField("address", addr).Error("Couldn't parse address")
+			continue
+		}
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+func (s ipv6Stack) filterIPs(ips []net.IP) []net.IP {
+	// ip.IsGlobalUnicast() returns true for:
+	// GUA = Global Unicast Address
+	// ULA = Unique Local Address
+	// We prefer GUA over ULA.
+	ipv6s := []net.IP{}
+	for _, ip := range ips {
+		if ip.IsGlobalUnicast() && ip.To4() == nil {
+			ipv6s = append(ipv6s, ip)
+		}
+	}
+
+	return ipv6s
+}
+
+func (s ipv4Stack) filterIPs(ips []net.IP) []net.IP {
+	ipv4s := []net.IP{}
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			ipv4s = append(ipv4s, ip)
+		}
+	}
+
+	return ipv4s
+}
+
+func (s ipv6Stack) sortIPs(ips []net.IP) []net.IP {
+	// Sort addresses placing GUAs first
+	sort.Slice(ips, func(i, j int) bool {
+		return ipv6IsGUA(ips[i]) && !ipv6IsGUA(ips[j]) ||
+			ipv6IsEUI64(ips[i]) && !ipv6IsEUI64(ips[j])
+	})
+	return ips
+}
+
+func (s ipv4Stack) sortIPs(ips []net.IP) []net.IP {
+	return ips
+}
+
+func (s baseIpStack) pickIP(ips []net.IP) net.IP {
+	netPrioritySubnets := []net.IPNet{}
+	for _, subnet := range s.cfg.prioritySubnets {
+		_, ipNet, err := net.ParseCIDR(subnet)
+		if err != nil {
+			log.WithError(err).WithField("subnet", subnet).Error("Couldn't parse subnet")
+			continue
+		}
+		netPrioritySubnets = append(netPrioritySubnets, *ipNet)
+	}
+
+	maxWeight := len(netPrioritySubnets)
+	weightedAddresses := make(map[string]int)
+	for _, ip := range ips {
+		weightedAddresses[ip.String()] = maxWeight
+		for i, ipNet := range netPrioritySubnets {
+			if ipNet.Contains(ip) {
+				weightedAddresses[ip.String()] = i
+				break
+			}
+		}
+	}
+	log.WithFields(log.Fields{
+		"addresses": ips,
+		"weighted":  weightedAddresses,
+	}).Debug("Found and weighted public IP addresses")
+
+	var selectedIp string
+	selectedWeight := maxWeight + 1
+	for ip, weight := range weightedAddresses {
+		if weight < selectedWeight {
+			selectedIp = ip
+			selectedWeight = weight
+		}
+	}
+
+	return net.ParseIP(selectedIp)
+}
+
+func (s ipv6Stack) logIP(ip net.IP) {
+	if !ipv6IsEUI64(ip) {
+		log.Warn("The selected address doesn't have a unique EUI-64, it may change frequently")
+	}
+	if !ipv6IsGUA(ip) {
+		log.Warn("The selected address is not a GUA, it may not be routable")
+	}
+}
+
+func (s ipv4Stack) logIP(ip net.IP) {
+	// if ipv4IsPrivate(ip) {
+	//     log.Warn("The selected address is a private IP, it may not be routable")
+	// }
+}
+
+func (bs baseIpStack) getOldIp() string {
+	ip, err := os.ReadFile(bs.cfg.stateFilepath)
+	if err != nil {
+		log.WithError(err).Warn("Can't get old ipv6 address")
+		return "INVALID"
+	}
+	return string(ip)
+}
+
+func (bs baseIpStack) setOldIp(ip string) {
+	err := os.WriteFile(bs.cfg.stateFilepath, []byte(ip), 0o644)
+	if err != nil {
+		log.WithError(err).Error("Can't write state file")
+	}
+}
+
+// Custom function to check if an IPv6 address is a GUA.
+// net.IP.IsGlobalUnicast() returns true also for ULAs.
+func ipv6IsGUA(ip net.IP) bool {
+	return ip[0]&0b11100000 == 0b00100000
+}
+
+// Custom function to check if an IPv6 address is generated using the EUI-64 format.
+// See RFC 4291, section 2.5.1.
+func ipv6IsEUI64(ip net.IP) bool {
+	// If the seventh bit from the left of the Interface ID is 1, and "FF FE" is
+	// found in the middle of the Interface ID, then the address is generated
+	// using the EUI-64 format.
+	return ip[8]&0b00000010 == 0b00000010 && ip[11] == 0xff && ip[12] == 0xfe
+}

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cloudflare/cloudflare-go v0.91.0 h1:L7IR+86qrZuEMSjGFg4cwRwtHqC8uCPmMUkP7BD4CPw=
-github.com/cloudflare/cloudflare-go v0.91.0/go.mod h1:nUqvBUUDRxNzsDSQjbqUNWHEIYAoUlgRmcAzMKlFdKs=
 github.com/cloudflare/cloudflare-go v0.92.0 h1:ltJvGvqZ4G6Fm2hHOYZ5RWpJQcrM0oDrsjjZydZhFJQ=
 github.com/cloudflare/cloudflare-go v0.92.0/go.mod h1:nUqvBUUDRxNzsDSQjbqUNWHEIYAoUlgRmcAzMKlFdKs=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
This PR implements IPv4-specific logic and adds a new flag `--stack` that can be either `ipv4` or `ipv6` (default). When selecting `ipv4`, only IPv4 addresses are processed, records created in Cloudflare have type `A`.