### PR TITLE
chore: adds riscv64 binary/docker release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
   - linux_mipsle
   - linux_mips64
   - linux_mips64le
+  - linux_riscv64
   - darwin_amd64
   - darwin_arm64
   - windows_amd64
@@ -116,6 +117,16 @@ dockers:
   use: buildx
   build_flag_templates:
   - --platform=linux/arm/7
+- goos: linux
+  goarch: riscv64
+  image_templates:
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Tag }}-linux-riscv64
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}-linux-riscv64
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}-linux-riscv64
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:latest-linux-riscv64
+  use: buildx
+  build_flag_templates:
+  - --platform=linux/riscv64
 docker_manifests:
 - name_template: ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Tag }}
   image_templates:
@@ -123,21 +134,25 @@ docker_manifests:
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Tag }}-linux-arm64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Tag }}-linux-arm-6
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Tag }}-linux-arm-7
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Tag }}-linux-riscv64
 - name_template: ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}
   image_templates:
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}-linux-amd64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}-linux-arm64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}-linux-arm-6
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}-linux-arm-7
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}-linux-riscv64
 - name_template: ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}
   image_templates:
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}-linux-amd64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}-linux-arm64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}-linux-arm-6
   - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}-linux-arm-7
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:{{ .Major }}.{{ .Minor }}-linux-riscv64
 - name_template: ghcr.io/zebradil/cloudflare-dynamic-dns:latest
   image_templates:
   - ghcr.io/zebradil/cloudflare-dynamic-dns:latest-linux-amd64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:latest-linux-arm64
   - ghcr.io/zebradil/cloudflare-dynamic-dns:latest-linux-arm-6
   - ghcr.io/zebradil/cloudflare-dynamic-dns:latest-linux-arm-7
+  - ghcr.io/zebradil/cloudflare-dynamic-dns:latest-linux-riscv64

--- a/.goreleaser.ytt.yml
+++ b/.goreleaser.ytt.yml
@@ -14,6 +14,7 @@
 #@   ("linux", "mipsle", ""),
 #@   ("linux", "mips64", ""),
 #@   ("linux", "mips64le", ""),
+#@   ("linux", "riscv64", ""),
 #@   ("darwin", "amd64", ""),
 #@   ("darwin", "arm64", ""),
 #@   ("windows", "amd64", ""),
@@ -24,6 +25,7 @@
 #@   ("linux", "arm64", ""),
 #@   ("linux", "arm", "6"),
 #@   ("linux", "arm", "7"),
+#@   ("linux", "riscv64", ""),
 #@ ]
 #@ versions = [
 #@   '{{ .Tag }}',


### PR DESCRIPTION
Tested on Milkv Megrez

```
$ uname -a
Linux milkv-megrez-2 6.6.73-win2030 #2025.01.23.02.46+aeb0f375c SMP Thu Jan 23 03:08:39 UTC 2025 riscv64
GNU/Linux
$ ./cloudflare-dynamic-dns --version
cloudflare-dynamic-dns version dev, commit none, built at unknown
```